### PR TITLE
Use CoreData for comparison and comparisonStock storage

### DIFF
--- a/ChartInsight.xcodeproj/project.pbxproj
+++ b/ChartInsight.xcodeproj/project.pbxproj
@@ -24,57 +24,41 @@
 		808259332A8EC047004A0619 /* AccessibilityId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808259302A8E9C2A004A0619 /* AccessibilityId.swift */; };
 		808A32C82A8996A70016CC78 /* WatchlistViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808A32C72A8996A70016CC78 /* WatchlistViewModelTests.swift */; };
 		808A32E22A899B4E0016CC78 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808A32E12A899B4E0016CC78 /* UITests.swift */; };
-		808A32EA2A89A5570016CC78 /* AddStockController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809F32342A36C7430018526F /* AddStockController.swift */; };
-		8096A45C2A7C640000F5FA88 /* WatchlistViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802E48D42A46278B00D02E8F /* WatchlistViewController.swift */; };
-		8096A45D2A7C646200F5FA88 /* ScrollChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80278A752A4CE3240051CFBE /* ScrollChartView.swift */; };
-		8096A4642A7C6DAA00F5FA88 /* ChartRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80278A782A4DEE5B0051CFBE /* ChartRenderer.swift */; };
 		8096A4662A7C6DFD00F5FA88 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096A4652A7C6DFD00F5FA88 /* Mocks.swift */; };
 		80975B7E2A892A1F00C8AAB8 /* ScrollChartViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D6D1E42A86EE9700F26527 /* ScrollChartViewModelTests.swift */; };
 		8097DB0A2A40BC38003E11E0 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8097DB092A40BC38003E11E0 /* UIColor+Extensions.swift */; };
 		8097DB122A422FB4003E11E0 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8097DB112A422FB4003E11E0 /* SettingsViewController.swift */; };
 		809F32352A36C7430018526F /* AddStockController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809F32342A36C7430018526F /* AddStockController.swift */; };
 		80A1164C2A89552200E2D3A5 /* BarUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1164B2A89552200E2D3A5 /* BarUnit.swift */; };
-		80A1164D2A89552200E2D3A5 /* BarUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1164B2A89552200E2D3A5 /* BarUnit.swift */; };
 		80A1164F2A896C7C00E2D3A5 /* WatchlistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1164E2A896C7C00E2D3A5 /* WatchlistViewModel.swift */; };
-		80A116502A896C7C00E2D3A5 /* WatchlistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1164E2A896C7C00E2D3A5 /* WatchlistViewModel.swift */; };
 		80A48AA42A49F686001E5E04 /* ChartStyleControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A48AA32A49F686001E5E04 /* ChartStyleControl.swift */; };
 		80AA23252A4902EB004F95F0 /* ChartOptionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA23242A4902EB004F95F0 /* ChartOptionsController.swift */; };
 		80ACF8C92A4F361B001A1D7B /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ACF8C82A4F361B001A1D7B /* Metrics.swift */; };
-		80ACF8CA2A4F361B001A1D7B /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ACF8C82A4F361B001A1D7B /* Metrics.swift */; };
 		80ACF8CC2A4F85FD001A1D7B /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ACF8CB2A4F85FD001A1D7B /* WebViewController.swift */; };
+		80B636ED2A915A87004CDD81 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B636EC2A915A87004CDD81 /* CoreDataStack.swift */; };
 		80B858B32A4B849900139EBA /* DBActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858A82A4B849900139EBA /* DBActor.swift */; };
 		80B858B52A4B849900139EBA /* FundamentalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858A92A4B849900139EBA /* FundamentalService.swift */; };
-		80B858B62A4B849900139EBA /* FundamentalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858A92A4B849900139EBA /* FundamentalService.swift */; };
 		80B858B72A4B849900139EBA /* Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AA2A4B849900139EBA /* Comparison.swift */; };
-		80B858B82A4B849900139EBA /* Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AA2A4B849900139EBA /* Comparison.swift */; };
-		80B858B92A4B849900139EBA /* Stock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AC2A4B849900139EBA /* Stock.swift */; };
-		80B858BA2A4B849900139EBA /* Stock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AC2A4B849900139EBA /* Stock.swift */; };
+		80B858B92A4B849900139EBA /* ComparisonStock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AC2A4B849900139EBA /* ComparisonStock.swift */; };
 		80B858BB2A4B849900139EBA /* BarData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AD2A4B849900139EBA /* BarData.swift */; };
-		80B858BC2A4B849900139EBA /* BarData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AD2A4B849900139EBA /* BarData.swift */; };
 		80B858BD2A4B849900139EBA /* BigNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AE2A4B849900139EBA /* BigNumberFormatter.swift */; };
-		80B858BE2A4B849900139EBA /* BigNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AE2A4B849900139EBA /* BigNumberFormatter.swift */; };
 		80B858BF2A4B849900139EBA /* HistoricalDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AF2A4B849900139EBA /* HistoricalDataService.swift */; };
-		80B858C02A4B849900139EBA /* HistoricalDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858AF2A4B849900139EBA /* HistoricalDataService.swift */; };
 		80B858C12A4B849900139EBA /* ChartElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858B02A4B849900139EBA /* ChartElements.swift */; };
-		80B858C22A4B849900139EBA /* ChartElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858B02A4B849900139EBA /* ChartElements.swift */; };
 		80B858C42A4BEC0200139EBA /* StockActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858C32A4BEC0200139EBA /* StockActor.swift */; };
-		80B858C52A4BEC0200139EBA /* StockActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858C32A4BEC0200139EBA /* StockActor.swift */; };
 		80B966AA2A70630B003DB7C8 /* StockActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B966A92A70630B003DB7C8 /* StockActorTests.swift */; };
 		80B966AE2A706BC7003DB7C8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B966AD2A706BC7003DB7C8 /* UIKit.framework */; };
 		80B966B02A706BE5003DB7C8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B966AF2A706BE5003DB7C8 /* Foundation.framework */; };
 		80B966B52A706E99003DB7C8 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8097DB092A40BC38003E11E0 /* UIColor+Extensions.swift */; };
 		80D3DB792A55C2B000E063B9 /* StockChangeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D3DB782A55C2B000E063B9 /* StockChangeService.swift */; };
-		80D3DB7A2A55C2B000E063B9 /* StockChangeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D3DB782A55C2B000E063B9 /* StockChangeService.swift */; };
 		80D5B9EB2A294F2100314733 /* ChartInsightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D5B9EA2A294F2100314733 /* ChartInsightTests.swift */; };
 		80D5B9F22A29518800314733 /* BigNumberFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D5B9F12A29518800314733 /* BigNumberFormatterTests.swift */; };
+		80DE194E2A8F2C4F00398F8B /* CoreDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 80DE194C2A8F2C4F00398F8B /* CoreDataModel.xcdatamodeld */; };
 		80E586EE2A433E6100A380AA /* ProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E586ED2A433E6100A380AA /* ProgressIndicator.swift */; };
 		80E587332A435BB700A380AA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E587322A435BB700A380AA /* AppDelegate.swift */; };
 		80E587362A435DE800A380AA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E587352A435DE800A380AA /* SceneDelegate.swift */; };
 		80EA06632A7C8217009FED8E /* WatchlistViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EA06622A7C8217009FED8E /* WatchlistViewControllerTests.swift */; };
-		80EA06652A7C839B009FED8E /* DBActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B858A82A4B849900139EBA /* DBActor.swift */; };
 		80EA06672A7C8B8B009FED8E /* UIViewController+TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EA06662A7C8B8B009FED8E /* UIViewController+TestHelper.swift */; };
 		80EA06692A7D7168009FED8E /* ScrollChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096A4592A7C633400F5FA88 /* ScrollChartViewModel.swift */; };
-		80EA066A2A7DAE4E009FED8E /* ScrollChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096A4592A7C633400F5FA88 /* ScrollChartViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,10 +111,11 @@
 		80AA23242A4902EB004F95F0 /* ChartOptionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartOptionsController.swift; sourceTree = "<group>"; };
 		80ACF8C82A4F361B001A1D7B /* Metrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
 		80ACF8CB2A4F85FD001A1D7B /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		80B636EC2A915A87004CDD81 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 		80B858A82A4B849900139EBA /* DBActor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBActor.swift; sourceTree = "<group>"; };
 		80B858A92A4B849900139EBA /* FundamentalService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FundamentalService.swift; sourceTree = "<group>"; };
 		80B858AA2A4B849900139EBA /* Comparison.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comparison.swift; sourceTree = "<group>"; };
-		80B858AC2A4B849900139EBA /* Stock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stock.swift; sourceTree = "<group>"; };
+		80B858AC2A4B849900139EBA /* ComparisonStock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComparisonStock.swift; sourceTree = "<group>"; };
 		80B858AD2A4B849900139EBA /* BarData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarData.swift; sourceTree = "<group>"; };
 		80B858AE2A4B849900139EBA /* BigNumberFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BigNumberFormatter.swift; sourceTree = "<group>"; };
 		80B858AF2A4B849900139EBA /* HistoricalDataService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoricalDataService.swift; sourceTree = "<group>"; };
@@ -146,6 +131,7 @@
 		80D5B9EA2A294F2100314733 /* ChartInsightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartInsightTests.swift; sourceTree = "<group>"; };
 		80D5B9F12A29518800314733 /* BigNumberFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigNumberFormatterTests.swift; sourceTree = "<group>"; };
 		80D6D1E42A86EE9700F26527 /* ScrollChartViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollChartViewModelTests.swift; sourceTree = "<group>"; };
+		80DE194D2A8F2C4F00398F8B /* CoreDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = CoreDataModel.xcdatamodel; sourceTree = "<group>"; };
 		80E586ED2A433E6100A380AA /* ProgressIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicator.swift; sourceTree = "<group>"; };
 		80E587322A435BB700A380AA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		80E587352A435DE800A380AA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -193,6 +179,8 @@
 				0B42BC321C420C8100139C33 /* metrics.plist */,
 				0B42BC301C420C8100139C33 /* charts.db */,
 				808259302A8E9C2A004A0619 /* AccessibilityId.swift */,
+				80DE194C2A8F2C4F00398F8B /* CoreDataModel.xcdatamodeld */,
+				80B636EC2A915A87004CDD81 /* CoreDataStack.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -295,9 +283,9 @@
 				80B858AE2A4B849900139EBA /* BigNumberFormatter.swift */,
 				80B858B02A4B849900139EBA /* ChartElements.swift */,
 				80B858AA2A4B849900139EBA /* Comparison.swift */,
+				80B858AC2A4B849900139EBA /* ComparisonStock.swift */,
 				80B858A82A4B849900139EBA /* DBActor.swift */,
 				80ACF8C82A4F361B001A1D7B /* Metrics.swift */,
-				80B858AC2A4B849900139EBA /* Stock.swift */,
 				80B858C32A4BEC0200139EBA /* StockActor.swift */,
 			);
 			path = Models;
@@ -489,6 +477,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				80E587332A435BB700A380AA /* AppDelegate.swift in Sources */,
+				80DE194E2A8F2C4F00398F8B /* CoreDataModel.xcdatamodeld in Sources */,
 				80A1164C2A89552200E2D3A5 /* BarUnit.swift in Sources */,
 				80B858BB2A4B849900139EBA /* BarData.swift in Sources */,
 				80B858B72A4B849900139EBA /* Comparison.swift in Sources */,
@@ -502,6 +491,7 @@
 				808259312A8E9C2A004A0619 /* AccessibilityId.swift in Sources */,
 				80B858B32A4B849900139EBA /* DBActor.swift in Sources */,
 				80AA23252A4902EB004F95F0 /* ChartOptionsController.swift in Sources */,
+				80B636ED2A915A87004CDD81 /* CoreDataStack.swift in Sources */,
 				80EA06692A7D7168009FED8E /* ScrollChartViewModel.swift in Sources */,
 				80278A762A4CE3240051CFBE /* ScrollChartView.swift in Sources */,
 				80D3DB792A55C2B000E063B9 /* StockChangeService.swift in Sources */,
@@ -510,7 +500,7 @@
 				80B858BD2A4B849900139EBA /* BigNumberFormatter.swift in Sources */,
 				802E48D52A46278B00D02E8F /* WatchlistViewController.swift in Sources */,
 				80A1164F2A896C7C00E2D3A5 /* WatchlistViewModel.swift in Sources */,
-				80B858B92A4B849900139EBA /* Stock.swift in Sources */,
+				80B858B92A4B849900139EBA /* ComparisonStock.swift in Sources */,
 				8097DB0A2A40BC38003E11E0 /* UIColor+Extensions.swift in Sources */,
 				80B858C42A4BEC0200139EBA /* StockActor.swift in Sources */,
 				801191882A42734B001C6ADD /* AddFundamentalController.swift in Sources */,
@@ -533,32 +523,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				80B966B52A706E99003DB7C8 /* UIColor+Extensions.swift in Sources */,
-				80D3DB7A2A55C2B000E063B9 /* StockChangeService.swift in Sources */,
-				80EA066A2A7DAE4E009FED8E /* ScrollChartViewModel.swift in Sources */,
 				80B966AA2A70630B003DB7C8 /* StockActorTests.swift in Sources */,
-				80EA06652A7C839B009FED8E /* DBActor.swift in Sources */,
-				80A1164D2A89552200E2D3A5 /* BarUnit.swift in Sources */,
-				80B858B62A4B849900139EBA /* FundamentalService.swift in Sources */,
-				80B858C02A4B849900139EBA /* HistoricalDataService.swift in Sources */,
-				80B858BC2A4B849900139EBA /* BarData.swift in Sources */,
 				808259332A8EC047004A0619 /* AccessibilityId.swift in Sources */,
-				808A32EA2A89A5570016CC78 /* AddStockController.swift in Sources */,
 				80975B7E2A892A1F00C8AAB8 /* ScrollChartViewModelTests.swift in Sources */,
-				8096A45D2A7C646200F5FA88 /* ScrollChartView.swift in Sources */,
-				80B858C22A4B849900139EBA /* ChartElements.swift in Sources */,
 				80D5B9F22A29518800314733 /* BigNumberFormatterTests.swift in Sources */,
-				80B858C52A4BEC0200139EBA /* StockActor.swift in Sources */,
-				80B858B82A4B849900139EBA /* Comparison.swift in Sources */,
 				80D5B9EB2A294F2100314733 /* ChartInsightTests.swift in Sources */,
-				8096A45C2A7C640000F5FA88 /* WatchlistViewController.swift in Sources */,
-				80ACF8CA2A4F361B001A1D7B /* Metrics.swift in Sources */,
 				80EA06672A7C8B8B009FED8E /* UIViewController+TestHelper.swift in Sources */,
 				80EA06632A7C8217009FED8E /* WatchlistViewControllerTests.swift in Sources */,
-				80B858BE2A4B849900139EBA /* BigNumberFormatter.swift in Sources */,
-				8096A4642A7C6DAA00F5FA88 /* ChartRenderer.swift in Sources */,
 				808A32C82A8996A70016CC78 /* WatchlistViewModelTests.swift in Sources */,
-				80A116502A896C7C00E2D3A5 /* WatchlistViewModel.swift in Sources */,
-				80B858BA2A4B849900139EBA /* Stock.swift in Sources */,
 				8096A4662A7C6DFD00F5FA88 /* Mocks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -908,6 +880,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		80DE194C2A8F2C4F00398F8B /* CoreDataModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				80DE194D2A8F2C4F00398F8B /* CoreDataModel.xcdatamodel */,
+			);
+			currentVersion = 80DE194D2A8F2C4F00398F8B /* CoreDataModel.xcdatamodel */;
+			path = CoreDataModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 0BB7F515183C31B90040F1C6 /* Project object */;
 }

--- a/ChartInsight.xcodeproj/project.pbxproj
+++ b/ChartInsight.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		80EA06632A7C8217009FED8E /* WatchlistViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EA06622A7C8217009FED8E /* WatchlistViewControllerTests.swift */; };
 		80EA06672A7C8B8B009FED8E /* UIViewController+TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EA06662A7C8B8B009FED8E /* UIViewController+TestHelper.swift */; };
 		80EA06692A7D7168009FED8E /* ScrollChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8096A4592A7C633400F5FA88 /* ScrollChartViewModel.swift */; };
+		80FB17172A91BDD5003F8069 /* Stock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FB17162A91BDD5003F8069 /* Stock.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -139,6 +140,7 @@
 		80EA06622A7C8217009FED8E /* WatchlistViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchlistViewControllerTests.swift; sourceTree = "<group>"; };
 		80EA06642A7C831E009FED8E /* ChartInsightTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ChartInsightTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		80EA06662A7C8B8B009FED8E /* UIViewController+TestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIViewController+TestHelper.swift"; path = "Helpers/UIViewController+TestHelper.swift"; sourceTree = "<group>"; };
+		80FB17162A91BDD5003F8069 /* Stock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stock.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -286,6 +288,7 @@
 				80B858AC2A4B849900139EBA /* ComparisonStock.swift */,
 				80B858A82A4B849900139EBA /* DBActor.swift */,
 				80ACF8C82A4F361B001A1D7B /* Metrics.swift */,
+				80FB17162A91BDD5003F8069 /* Stock.swift */,
 				80B858C32A4BEC0200139EBA /* StockActor.swift */,
 			);
 			path = Models;
@@ -505,6 +508,7 @@
 				80B858C42A4BEC0200139EBA /* StockActor.swift in Sources */,
 				801191882A42734B001C6ADD /* AddFundamentalController.swift in Sources */,
 				80E586EE2A433E6100A380AA /* ProgressIndicator.swift in Sources */,
+				80FB17172A91BDD5003F8069 /* Stock.swift in Sources */,
 				80E587362A435DE800A380AA /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Controllers/ChartOptionsController.swift
+++ b/Controllers/ChartOptionsController.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class ChartOptionsController: UITableViewController {
     public var sparklineKeys: [String] = []
-    public var stock: Stock
+    public var stock: ComparisonStock
     private weak var delegate: ChartOptionsDelegate?
     private enum SectionType: Int {
         case chartType, chartColor, financials, technicals, setDefaults
@@ -32,7 +32,7 @@ class ChartOptionsController: UITableViewController {
     private var listedMetricsEnabled: [Bool] = [] // parallel array to preseve sort
 
     /// Desiginated initializer sets stock and delegate
-    public init(stock: Stock, delegate: ChartOptionsDelegate?) {
+    public init(stock: ComparisonStock, delegate: ChartOptionsDelegate?) {
         self.stock = stock
         self.delegate = delegate
         typeSegmentedControl = ChartStyleControl(type: .chartType, frame: segmentFrame, stock: stock)
@@ -42,9 +42,9 @@ class ChartOptionsController: UITableViewController {
         colorSegmentedControl.delegate = self
     }
 
-    ///  Initializer required by parent class for use with storyboards
-    required convenience init?(coder aDecoder: NSCoder) {
-        self.init(stock: Stock(), delegate: nil)
+    ///  Initializer required by parent class for use with storyboards which this app doesn't use
+    required convenience init?(coder: NSCoder) {
+        self.init(stock: ComparisonStock(), delegate: nil)
     }
 
     override func viewDidLoad() {
@@ -285,7 +285,7 @@ class ChartOptionsController: UITableViewController {
 
     /// User clicked on Update defaults row
     @objc func updateDefaults() {
-        UserDefaults.standard.setValue(stock.chartType.rawValue, forKey: "chartTypeDefault")
+        UserDefaults.standard.setValue(stock.chartType, forKey: "chartTypeDefault")
         UserDefaults.standard.setValue(stock.technicalList, forKey: "technicalDefaults")
         UserDefaults.standard.setValue(stock.fundamentalList, forKey: "fundamentalDefaults")
         defaultsActionText = "Default Chart Settings Saved"
@@ -294,9 +294,9 @@ class ChartOptionsController: UITableViewController {
 
     /// User clicked on chartStyleControl to change the chart type
     /// Returns the updated stock so caller can update its copy
-    func chartTypeChanged(to chartTypeIndex: Int) -> Stock {
+    func chartTypeChanged(to chartTypeIndex: Int) -> ComparisonStock {
         if let newChartType = ChartType(rawValue: chartTypeIndex) {
-            stock.chartType = newChartType
+            stock.chartType = Int64(chartTypeIndex)
             colorSegmentedControl.createSegments(for: newChartType)
             tableView.reloadData()
             Task {
@@ -308,7 +308,7 @@ class ChartOptionsController: UITableViewController {
 
     /// User clicked on chartStyleControl to change the chart color
     /// Returns the updated stock so caller can update its copy
-    public func chartColorChanged(to colorIndex: Int) -> Stock {
+    public func chartColorChanged(to colorIndex: Int) -> ComparisonStock {
         stock.setColors(upHexColor: ChartHexColor.allCases[colorIndex])
         tableView.reloadData()
         Task {

--- a/Controllers/WebViewController.swift
+++ b/Controllers/WebViewController.swift
@@ -120,19 +120,19 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
 
         guard webView.url?.absoluteString.contains("chartinsight.com") == true else { return }
 
-        webView.evaluateJavaScript("document.querySelector('#leftTickTicker')?.innerHTML") { (result, error) in
-            guard error == nil, let ticker = result as? String else { return }
+        webView.evaluateJavaScript("document.querySelector('#leftTickTicker')?.innerHTML") { (ticker, error) in
+            guard error == nil, let ticker = ticker as? String else { return }
 
             Task {
                 var buttonText = ""
-                let comparisonList = await DBActor.shared.comparisonList(ticker: ticker)
-                if comparisonList.isEmpty {
+                let comparison = Comparison.findExisting(ticker: ticker)
+                if comparison == nil {
                     if let stock = await DBActor.shared.getStock(ticker: ticker) {
                         buttonText = "Add \(ticker) to Watchlist"
                         self.stock = stock
                     }
                 } else {
-                    self.comparison = comparisonList[0]
+                    self.comparison = comparison
                     buttonText = "View \(ticker) on Watchlist"
                 }
 

--- a/Data/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/Data/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Comparison" representedClassName="Comparison" syncable="YES">
+        <attribute name="created" attributeType="Date" defaultDateTimeInterval="714188040" usesScalarValueType="NO"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <relationship name="stockSet" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ComparisonStock" inverseName="comparison" inverseEntity="ComparisonStock"/>
+    </entity>
+    <entity name="ComparisonStock" representedClassName="ComparisonStock" syncable="YES">
+        <attribute name="chartType" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="fundamentalList" attributeType="String" defaultValueString=""/>
+        <attribute name="hasFundamentals" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="hexColor" attributeType="String" defaultValueString="009900"/>
+        <attribute name="name" attributeType="String" maxValueString="63" defaultValueString=""/>
+        <attribute name="startDateString" attributeType="String" defaultValueString="20090102"/>
+        <attribute name="stockId" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="technicalList" attributeType="String" defaultValueString=""/>
+        <attribute name="ticker" attributeType="String" maxValueString="63" defaultValueString=""/>
+        <relationship name="comparison" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Comparison" inverseName="stockSet" inverseEntity="Comparison"/>
+    </entity>
+</model>

--- a/Data/CoreDataStack.swift
+++ b/Data/CoreDataStack.swift
@@ -1,0 +1,46 @@
+//
+//  CoreDataStack.swift
+//  ChartInsight
+//
+//  Created by Eric Kennedy on 8/19/23.
+//  Copyright © 2023 Chart Insight LLC. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+public final class CoreDataStack {
+    static let shared = CoreDataStack(modelName: "CoreDataModel")
+
+    private let modelName: String
+
+    public init(modelName: String) {
+        self.modelName = modelName
+    }
+
+    public lazy var container: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: self.modelName)
+        container.loadPersistentStores { _, error in
+            container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+            if let error {
+                print("Unresolved error \(error)")
+            }
+        }
+        return container
+    }()
+
+    public lazy var viewContext: NSManagedObjectContext = {
+        let context = container.viewContext
+        context.automaticallyMergesChangesFromParent = true
+        return context
+    }()
+
+    public func save() {
+        do {
+            try container.viewContext.save()
+        } catch {
+            print("Error occured while saving \(error)")
+        }
+    }
+
+}

--- a/Models/ChartElements.swift
+++ b/Models/ChartElements.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 struct ChartElements {
-    public var stock: Stock
+    public var stock: ComparisonStock
     public var monthLabels: [String] = []
     public var monthLines: [CGPoint] = []
     // Fundamental reports

--- a/Models/ComparisonStock.swift
+++ b/Models/ComparisonStock.swift
@@ -10,6 +10,7 @@
 //  Copyright © 2023 Chart Insight LLC. All rights reserved.
 //
 
+import CoreData
 import Foundation
 import UIKit
 
@@ -17,11 +18,26 @@ public enum ChartType: Int, CaseIterable {
     case ohlc, hlc, candle, close
 }
 
-struct Stock {
+public struct Stock {
     public var  id: Int = 0
-    public var  chartType: ChartType = .close
-    public var  comparisonStockId: Int = 0
     public var  hasFundamentals: Bool = true
+    public var  ticker: String = ""
+    public var  name: String = ""
+    public var  startDateString: String = "" // full text search returns a string value
+}
+
+@objc(ComparisonStock)
+public class ComparisonStock: NSManagedObject {
+    @NSManaged public var stockId: Int64
+    @NSManaged public var chartType: Int64
+    @NSManaged public var ticker: String
+    @NSManaged public var name: String
+    @NSManaged public var hasFundamentals: Bool
+    @NSManaged public var fundamentalList: String
+    @NSManaged public var technicalList: String
+    @NSManaged public var startDateString: String
+    @NSManaged public var hexColor: String
+    @NSManaged public var comparison: Comparison?
     public var  color: UIColor = .red {
         willSet(newColor) {
             let (red, green, blue) = newColor.rgba
@@ -37,19 +53,16 @@ struct Stock {
             upColorHalfAlpha = UIColor.init(red: red, green: green, blue: blue, alpha: 0.5)
             colorInverse = UIColor.init(red: 1 - red, green: 1 - green, blue: 1 - blue, alpha: 1.0)
             colorInverseHalfAlpha = UIColor.init(red: 1 - red, green: 1 - green, blue: 1 - blue, alpha: 0.5)
+            hexColor = newColor.hexString
         }
     }
     public var  upColorHalfAlpha: UIColor = .init(red: 0, green: 0.6, blue: 0, alpha: 0.5)
-    public var  ticker: String = ""
-    public var  name: String = ""
-    public var  fundamentalList: String = ""
-    public var  technicalList: String = ""
-    public var  startDateString: String = "" // full text search returns a string value
-    public var  startDate: Date?             // converted from startDateString
 
-    public init() {
+    /// Initialize ComparisonStock using user default settings (if set) or app defaults
+    public override func awakeFromInsert() {
+        super.awakeFromInsert()
         if let defaultChartType = ChartType(rawValue: UserDefaults.standard.integer(forKey: "chartTypeDefault")) {
-            chartType = defaultChartType
+            chartType = Int64(defaultChartType.rawValue)
         }
 
         if let technicalDefaults = UserDefaults.standard.string(forKey: "technicalDefaults") {
@@ -65,11 +78,31 @@ struct Stock {
         }
     }
 
+    /// Set the stock chart colors from the saved hex value
+    public override func awakeFromFetch() {
+        if let colorFromHex = ChartHexColor(rawValue: hexColor) {
+            setColors(upHexColor: colorFromHex)
+        }
+    }
+
+    /// Use the values in the provided stock for this comparisonStock. Returns self to allow chaining methods.
+    public func setValues(with stock: Stock) -> ComparisonStock {
+        stockId = Int64(stock.id)
+        name = stock.name
+        ticker = stock.ticker
+        startDateString = stock.startDateString
+        hasFundamentals = stock.hasFundamentals
+        if hasFundamentals == false {
+            fundamentalList = ""
+        }
+        return self
+    }
+
     /// Set the up color using provided ChartHexColor value and if that value is .greenAndRed then down color is .red
-    public mutating func setColors(upHexColor: ChartHexColor) {
+    public func setColors(upHexColor: ChartHexColor) {
 
         upColor = upHexColor.color()
-        if upHexColor == .greenAndRed && chartType != .close {
+        if upHexColor == .greenAndRed && chartType != ChartType.close.rawValue {
             color = .red // upColor is green so other bars should be red
         } else {
             color = upColor
@@ -84,27 +117,34 @@ struct Stock {
         return false
     }
 
-    public mutating func addToFundamentals(_ metric: String) {
+    public func addToFundamentals(_ metric: String) {
         if fundamentalList.contains(metric) == false {
             fundamentalList = fundamentalList.appending("\(metric),")
         }
     }
 
-    public mutating func removeFromFundamentals(_ metric: String) {
+    public func removeFromFundamentals(_ metric: String) {
         if fundamentalList.contains(metric) {
             fundamentalList = fundamentalList.replacingOccurrences(of: "\(metric),", with: "")
         }
     }
 
-    public mutating func addToTechnicals(_ metric: String) {
+    public func addToTechnicals(_ metric: String) {
         if technicalList.contains(metric) == false {
             technicalList = technicalList.appending("\(metric),")
         }
     }
 
-    public mutating func removeFromTechnicals(_ metric: String) {
+    public func removeFromTechnicals(_ metric: String) {
         if technicalList.contains(metric) {
             technicalList = technicalList.replacingOccurrences(of: "\(metric),", with: "")
         }
+    }
+}
+
+// MARK: CoreData managed properties
+extension ComparisonStock: Identifiable {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ComparisonStock> {
+        return NSFetchRequest<ComparisonStock>(entityName: "ComparisonStock")
     }
 }

--- a/Models/ComparisonStock.swift
+++ b/Models/ComparisonStock.swift
@@ -18,14 +18,6 @@ public enum ChartType: Int, CaseIterable {
     case ohlc, hlc, candle, close
 }
 
-public struct Stock {
-    public var  id: Int = 0
-    public var  hasFundamentals: Bool = true
-    public var  ticker: String = ""
-    public var  name: String = ""
-    public var  startDateString: String = "" // full text search returns a string value
-}
-
 @objc(ComparisonStock)
 public class ComparisonStock: NSManagedObject {
     @NSManaged public var stockId: Int64

--- a/Models/Stock.swift
+++ b/Models/Stock.swift
@@ -1,0 +1,19 @@
+//
+//  Stock.swift
+//  ChartInsight
+//
+//  Stock objects are returned by the search results and are used to create ComparisonStock entries.
+//
+//  Created by Eric Kennedy on 8/19/23.
+//  Copyright © 2023 Chart Insight LLC. All rights reserved.
+//
+
+import Foundation
+
+public struct Stock {
+    public var id: Int = 0
+    public var hasFundamentals: Bool = true
+    public var ticker: String = ""
+    public var name: String = ""
+    public var startDateString: String = "20090102" // full text search returns a string value
+}

--- a/SceneDelegate.swift
+++ b/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Chart Insight LLC. All rights reserved.
 //
 
+import CoreData
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -30,8 +31,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
 
         scrollChartViewModel = ScrollChartViewModel(contentsScale: window.screen.scale)
-        watchlistViewModel = WatchlistViewModel(scrollChartViewModel: scrollChartViewModel)
+        watchlistViewModel = WatchlistViewModel(container: CoreDataStack.shared.container, scrollChartViewModel: scrollChartViewModel)
         watchlistViewController = WatchlistViewController(watchlistViewModel: watchlistViewModel)
+        settingsViewController.container = CoreDataStack.shared.container
 
         let isDarkMode = UserDefaults.standard.bool(forKey: "darkMode")
 

--- a/Services/FundamentalService.swift
+++ b/Services/FundamentalService.swift
@@ -29,7 +29,7 @@ final class FundamentalService {
     private let ticker: String
     private var url: URL?
 
-    init(for stock: Stock, delegate: StockActor) {
+    init(for stock: ComparisonStock, delegate: StockActor) {
         ticker = stock.ticker
         self.delegate = delegate
         formatRequestURL(keys: stock.fundamentalList)

--- a/Services/HistoricalDataService.swift
+++ b/Services/HistoricalDataService.swift
@@ -38,7 +38,7 @@ final class HistoricalDataService {
     private var nextClose: Date
     private var gregorian: Calendar?
     private var ticker: String
-    private var stockId: Int
+    private var stockId: Int64
     private var dateFormatter: DateFormatter
     private var isLoadingData: Bool
     private var countBars: Int
@@ -49,10 +49,10 @@ final class HistoricalDataService {
     private var lastOfflineError: Date
     private var ephemeralSession: URLSession = URLSession(configuration: .ephemeral) // skip web cache
 
-    public init(for stock: Stock, calendar: Calendar) {
+    public init(for stock: ComparisonStock, calendar: Calendar) {
         fetchedData = []
         isLoadingData = false
-        stockId = stock.id
+        stockId = stock.stockId
         ticker = stock.ticker
         gregorian = calendar
         (countBars, barsFromDB) = (0, 0)
@@ -281,7 +281,7 @@ final class HistoricalDataService {
         isLoadingData = false // allows StockActor to request intraday data if needed
 
         // save to DB after updating UI with historicalDataLoaded()
-        await DBActor.shared.save(fetchedData, stockId: stockId)
+        await DBActor.shared.save(fetchedData, stockId: Int64(stockId))
     }
 
     /// Call StockActor delegate and have it update the bar data on a background thread

--- a/Tests/BigNumberFormatterTests.swift
+++ b/Tests/BigNumberFormatterTests.swift
@@ -9,6 +9,8 @@
 import Foundation
 import XCTest
 
+@testable import ChartInsight
+
 final class BigNumberFormatterTests: XCTestCase {
 
     let showFractions: Float = 4.0

--- a/Tests/ChartInsightTests.swift
+++ b/Tests/ChartInsightTests.swift
@@ -8,6 +8,8 @@
 
 import XCTest
 
+@testable import ChartInsight
+
 final class ChartInsightTests: XCTestCase {
 
     override func setUpWithError() throws {

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -8,8 +8,11 @@
 //  Copyright © 2023 Chart Insight LLC. All rights reserved.
 //
 
+import CoreData
 import Foundation
 import UIKit
+
+@testable import ChartInsight
 
 final class SceneDelegate {
     public func showWebView(urlString: String) { }
@@ -21,8 +24,6 @@ extension Stock {
         stock.id = 1
         stock.name = "Apple"
         stock.ticker = "AAPL"
-        stock.startDateString = "20090102"
-        stock.fundamentalList = "CIRevenuePerShare,EarningsPerShareBasic,"
         return stock
     }
 
@@ -33,14 +34,27 @@ extension Stock {
         stock.name = "Cibus"
         stock.ticker = "CBUS"
         stock.startDateString = "20230601" // actual start date
-        stock.fundamentalList = "" // empty fundamentals to skip FundamentalService
         return stock
+    }
+}
+
+extension ComparisonStock {
+    /// Creates a new comparisonStock for AAPL. Caller will need to add it to a comparison.
+    static func testAAPL(context: NSManagedObjectContext) -> ComparisonStock {
+        return ComparisonStock(context: context).setValues(with: Stock.testAAPL())
+    }
+
+    /// Creates a comparisonStock with the least history for faster integration tests. Caller will need to add it to a comparison.
+    static func testStock(context: NSManagedObjectContext) -> ComparisonStock {
+        return ComparisonStock(context: context).setValues(with: Stock.testStock())
     }
 }
 
 class MockStockDelegate: StockActorDelegate, DBActorDelegate {
     func update(list newList: [Comparison], reloadComparison: Bool) {
     }
+
+    var requestFinishedCompletion: ((NSDecimalNumber) async -> Void)?
 
     var didRequestStart = false, didRequestCancel = false, didRequestFail = false, didRequestFinish = false
 
@@ -58,37 +72,5 @@ class MockStockDelegate: StockActorDelegate, DBActorDelegate {
 
     func requestFinished(newPercentChange: NSDecimalNumber) async {
         didRequestFinish = true
-    }
-}
-
-final class ProgressIndicator: UIView {
-    override init(frame: CGRect) { super.init(frame: frame) }
-    required convenience init?(coder: NSCoder) { self.init(frame: .zero) }
-    func reset() { }
-    func startAnimating() { }
-    func stopAnimating() { }
-}
-
-final class ChartOptionsController: UITableViewController {
-    public var sparklineKeys: [String] = []
-    public var stock: Stock
-    private weak var delegate: ChartOptionsDelegate?
-
-    public init(stock: Stock, delegate: ChartOptionsDelegate?) {
-        self.stock = stock
-        self.delegate = delegate
-        super.init(style: .plain)
-    }
-
-    required convenience init?(coder: NSCoder) {
-        self.init(stock: Stock.testAAPL(), delegate: nil)
-    }
-
-    public func chartTypeChanged(to chartTypeIndex: Int) -> Stock {
-        return Stock.testAAPL()
-    }
-
-    public func chartColorChanged(to colorIndex: Int) -> Stock {
-        return Stock.testAAPL()
     }
 }

--- a/Tests/WatchlistViewControllerTests.swift
+++ b/Tests/WatchlistViewControllerTests.swift
@@ -6,18 +6,29 @@
 //  Copyright © 2023 Chart Insight LLC. All rights reserved.
 //
 
+import CoreData
 import XCTest
+
+@testable import ChartInsight
 
 @MainActor final class WatchlistViewControllerTests: XCTestCase {
 
+    var container: NSPersistentContainer!
     var scrollChartViewModel: ScrollChartViewModel!
     var watchlistViewModel: WatchlistViewModel!
     var watchlistViewController: WatchlistViewController!
 
     /// Initialize fresh viewModels
     override func setUpWithError() throws {
+        container = NSPersistentContainer(name: "CoreDataModel")
+        container.loadPersistentStores { _, error in
+            if let error {
+                print("Unresolved error \(error)")
+            }
+        }
         scrollChartViewModel = ScrollChartViewModel(contentsScale: 2.0)
-        watchlistViewModel = WatchlistViewModel(scrollChartViewModel: scrollChartViewModel)
+        watchlistViewModel = WatchlistViewModel(container: CoreDataStack.shared.container, scrollChartViewModel: scrollChartViewModel)
+
         watchlistViewController = WatchlistViewController(watchlistViewModel: watchlistViewModel)
 
         watchlistViewController.triggerLifecycleIfNeeded()
@@ -27,12 +38,8 @@ import XCTest
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    /// DBActor.shared.moveIfNeeded provides the comparisonList to the MainActor so this test needs to use it
+    /// CoreData implementation of WatchlistViewModel.init(container, scrollChartModel:) fetches comparisonList so listCount > 0
     @MainActor func testUpdateWithList() async throws {
-        XCTAssert(0 == watchlistViewController.tableView(watchlistViewController.tableView, numberOfRowsInSection: 0))
-
-        await DBActor.shared.moveIfNeeded(delegate: watchlistViewModel)
-
         // MainActor should have received rows from the DBActor
         XCTAssert(0 < watchlistViewController.tableView(watchlistViewController.tableView, numberOfRowsInSection: 0))
     }

--- a/Tests/WatchlistViewModelTests.swift
+++ b/Tests/WatchlistViewModelTests.swift
@@ -6,22 +6,31 @@
 //  Copyright © 2023 Chart Insight LLC. All rights reserved.
 //
 
+import CoreData
 import XCTest
+
+@testable import ChartInsight
 
 @MainActor final class WatchlistViewModelTests: XCTestCase {
 
+    var container: NSPersistentContainer!
     var scrollChartViewModel: ScrollChartViewModel!
     var watchlistViewModel: WatchlistViewModel!
 
     /// Initialize fresh viewModels
     override func setUpWithError() throws {
+        container = NSPersistentContainer(name: "CoreDataModel")
+        container.loadPersistentStores { _, error in
+            if let error {
+                print("Unresolved error \(error)")
+            }
+        }
         scrollChartViewModel = ScrollChartViewModel(contentsScale: 2.0)
-        watchlistViewModel = WatchlistViewModel(scrollChartViewModel: scrollChartViewModel)
+        watchlistViewModel = WatchlistViewModel(container: CoreDataStack.shared.container, scrollChartViewModel: scrollChartViewModel)
     }
 
+    /// CoreData implementation of WatchlistViewModel.init(container, scrollChartModel:) fetches comparisonList so listCount > 0
     func testDidUpdateAfterDbFetch() async throws {
-
-        XCTAssert(0 == watchlistViewModel.listCount)
 
         let expectation = XCTestExpectation(description: "Expect didUpdate(_) closure to be called")
 

--- a/Views/ChartRenderer.swift
+++ b/Views/ChartRenderer.swift
@@ -102,7 +102,7 @@ struct ChartRenderer {
             context.fill(chartElements.blackVolume)
 
             context.setStrokeColor(chartElements.stock.upColor.cgColor)
-            if chartElements.stock.chartType == .close {
+            if chartElements.stock.chartType == ChartType.close.rawValue {
                 context.setLineJoin(.round)
                 strokeLineFromPoints(chartElements.points, context: context)
                 context.setLineJoin(.miter)

--- a/Views/ChartStyleControl.swift
+++ b/Views/ChartStyleControl.swift
@@ -29,7 +29,7 @@ final class ChartStyleControl: UIControl {
             }
         }
     }
-    private var stock: Stock
+    private var stock: ComparisonStock
     private let stackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
 
     @objc func tappedButton(button: UIButton) {
@@ -43,7 +43,7 @@ final class ChartStyleControl: UIControl {
         }
     }
 
-    public init(type: ChartStyleControlType, frame: CGRect, stock: Stock) {
+    public init(type: ChartStyleControlType, frame: CGRect, stock: ComparisonStock) {
         self.type = type
         self.stock = stock
         super.init(frame: frame)
@@ -60,8 +60,9 @@ final class ChartStyleControl: UIControl {
         backgroundColor = UIColor.systemBackground
     }
 
-    required convenience init?(coder aDecoder: NSCoder) {
-        self.init(type: .color, frame: .zero, stock: Stock())
+    ///  Initializer required by parent class for use with storyboards which this app doesn't use
+    required convenience init?(coder: NSCoder) {
+        self.init(type: .color, frame: .zero, stock: ComparisonStock(context: CoreDataStack.shared.viewContext))
     }
 
     /// Add segments to StackView by rendering images and creating a button for each image.
@@ -75,7 +76,7 @@ final class ChartStyleControl: UIControl {
                 if let miniChart = image(chartType: chartType, colorHex: .greenAndRed, showLabel: true) {
                     images.append(miniChart)
                 }
-                if stock.chartType == chartType {
+                if stock.chartType == chartType.rawValue {
                     selectedIndex = index
                 }
             }
@@ -127,7 +128,7 @@ final class ChartStyleControl: UIControl {
             ctx.cgContext.setLineWidth(1)
             ctx.cgContext.setStrokeColor(upCGColor)
 
-            if chartType == .close {
+            if chartType.rawValue == ChartType.close.rawValue {
                 ctx.cgContext.setLineJoin(.round)
                 ctx.cgContext.move(to: CGPoint(x: 2.5, y: 3))
                 ctx.cgContext.addLine(to: CGPoint(x: 5, y: 22))
@@ -149,7 +150,7 @@ final class ChartStyleControl: UIControl {
                 ctx.cgContext.addLine(to: CGPoint(x: 30.5, y: 17))
                 ctx.cgContext.drawPath(using: .stroke)
 
-                if chartType == .candle {
+                if chartType.rawValue == ChartType.candle.rawValue {
                     ctx.cgContext.setFillColor(upCGColor)
                     ctx.cgContext.fill([CGRect(x: 11, y: 6, width: 5, height: 15),
                                         CGRect(x: 28, y: 3, width: 5, height: 12)])
@@ -165,7 +166,7 @@ final class ChartStyleControl: UIControl {
                     ctx.cgContext.addLine(to: CGPoint(x: 34, y: 5))
                     ctx.cgContext.drawPath(using: .stroke)
 
-                    if chartType == .ohlc { // Add open
+                    if chartType.rawValue == ChartType.ohlc.rawValue { // Add open
                         ctx.cgContext.move(to: CGPoint(x: 9.5, y: 21))
                         ctx.cgContext.addLine(to: CGPoint(x: 13.5, y: 21))
                         ctx.cgContext.drawPath(using: .stroke)

--- a/Views/ScrollChartView.swift
+++ b/Views/ScrollChartView.swift
@@ -34,8 +34,9 @@ final class ScrollChartView: UIView {
         bindToViewModel()
     }
 
+    ///  Initializer required by parent class for use with storyboards which this app doesn't use
     required convenience init?(coder: NSCoder) {
-        self.init(viewModel: ScrollChartViewModel(contentsScale: UIScreen.main.scale)) // Required by UIKit but Storyboard isn't used
+        self.init(viewModel: ScrollChartViewModel(contentsScale: 2.0))
     }
 
     // MARK: - ViewModel
@@ -88,12 +89,13 @@ final class ScrollChartView: UIView {
     /// Apple deprecated the CoreGraphics function for rendering text with a specified CGContext so it is necessary
     /// to use UIGraphicsPushContext(context) to render text in the offscreen layerRef.context
     private func renderCharts(stockChartElements: [ChartElements]) {
+        guard let currentComparison = viewModel.comparison else { return }
         if var renderer = chartRenderer, let context = layerRef?.context {
             renderer.barUnit = viewModel.barUnit
             renderer.xFactor = viewModel.xFactor
             renderer.pxWidth = viewModel.pxWidth - viewModel.axisPadding
 
-            let chartText = renderer.renderCharts(comparison: viewModel.comparison, stockChartElements: stockChartElements)
+            let chartText = renderer.renderCharts(comparison: currentComparison, stockChartElements: stockChartElements)
 
             UIGraphicsPushContext(context) // required for textData.text.draw(at: withAttributes:)
             for textData in chartText {


### PR DESCRIPTION
Major refactor to use CoreData instead of SQLite for the watchlist data. Historical price data is still saved to sqlite charts.db and the list of all stocks also remains in charts.db for full text search.

The old Stock struct became the NSManagedObject class ComparisonStock. To make sure GitHub realized Stock.swift was renamed to ComparisonStock.swift, I waited until after the primary CoreData migration commit to move the minimal Stock struct into its own file.

All unit and UI tests pass.